### PR TITLE
Add venv path in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: /opt/venv/bin/python app.py

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ A Python-based web application that allows you to specify a link to a YouTube vi
 3.  Open your web browser and navigate to:
     [http://127.0.0.1:5000/](http://127.0.0.1:5000/)
 
+## Deploying with Nixpacks / Railway
+
+If you're deploying to a platform that uses [Nixpacks](https://nixpacks.com) such as
+Railway, make sure the build process knows how to start your application. A
+simple way to do this is to add a `Procfile` in the project root:
+
+```Procfile
+web: /opt/venv/bin/python app.py
+```
+
+Nixpacks will detect this file and use it as the start command. The application
+is configured to read the `PORT` environment variable, so it works on platforms
+that dynamically assign a port.
+
 ## File Structure
 
 ```

--- a/app.py
+++ b/app.py
@@ -127,4 +127,6 @@ def download_gif(filename):
     return send_from_directory(app.config['GENERATED_GIF_FOLDER'], filename, as_attachment=True)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    port = int(os.environ.get('PORT', 5000))
+    debug_mode = os.environ.get('DEBUG', 'false').lower() == 'true'
+    app.run(host='0.0.0.0', port=port, debug=debug_mode)


### PR DESCRIPTION
## Summary
- tweak Procfile to call Python from the Nixpacks venv
- update README with new Procfile example

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement yt-dlp)*
- `pytest -q` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.