### PR TITLE
Fix start command to use venv python

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: python app.py
-
+web: /opt/venv/bin/python app.py

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ A Python-based web application that allows you to specify a link to a YouTube vi
 If you're deploying to a platform that uses [Nixpacks](https://nixpacks.com) such as
 Railway, make sure the build process knows how to start your application. A
 simple way to do this is to add a `Procfile` in the project root:
+```Procfile
+web: /opt/venv/bin/python app.py
+```
 
 Nixpacks will detect this file and use it as the start command. The application
 is configured to read the `PORT` environment variable, so it works on platforms

--- a/tests/test_gif_generator.py
+++ b/tests/test_gif_generator.py
@@ -235,4 +235,3 @@ class TestGifGenerator(unittest.TestCase):
 if __name__ == '__main__':
     # This allows running the tests directly from this file
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
-```


### PR DESCRIPTION
## Summary
- run app with Python from the Nixpacks venv
- document the Procfile example
- clean up test file footer

## Testing
- `pytest -q` *(fails: pytest not installed)*