### PR TITLE
Fix: Set PYTHONPATH in Procfile to resolve ModuleNotFoundError

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: /opt/venv/bin/python app.py
+web: PYTHONPATH=/opt/venv/lib/python3.12/site-packages:$PYTHONPATH /opt/venv/bin/python app.py


### PR DESCRIPTION
The application was failing to find the `moviepy.editor` module at runtime, despite it being installed during the build process. This was likely due to the Python runtime environment not correctly identifying the site-packages directory of the virtual environment.

This commit modifies the `Procfile` to explicitly set the `PYTHONPATH` environment variable to include `/opt/venv/lib/python3.12/site-packages`. This ensures that the Python interpreter correctly locates installed packages, including `moviepy`, when the application starts.